### PR TITLE
Add /usr/local/sbin to PATH

### DIFF
--- a/bash/profile.symlink
+++ b/bash/profile.symlink
@@ -1,5 +1,6 @@
 # fix PATH before all
 export PATH=/usr/local/bin:${PATH%:/usr/local/bin}
+export PATH=/usr/local/sbin:${PATH%:/usr/local/sbin}
 
 # shortcut to this dotfiles path is $DOTFILES
 export DOTFILES=$HOME/.dotfiles


### PR DESCRIPTION
Homebrew ask to add /usr/local/sbin to PATH during `brew doctor`
on OSX 10.11
