### PR TITLE
Add git git-delete-squashed command

### DIFF
--- a/bin/git-delete-squashed
+++ b/bin/git-delete-squashed
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+git checkout -q master && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base master $branch) && [[ $(git cherry master $(git commit-tree $(git rev-parse $branch^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done


### PR DESCRIPTION
Adds `git delete-squashed` to delete squashed and merged branches to `master`.
Based on https://github.com/not-an-aardvark/git-delete-squashed