### PR TITLE
Hide "default interactive shell is now zsh"

### DIFF
--- a/bash/config.bash
+++ b/bash/config.bash
@@ -24,6 +24,9 @@ export HISTCONTROL=ignoredups
 export HISTCONTROL=ignoreboth
 export HISTIGNORE="&:ls:[bf]g:exit"
 
+# Hide "default interactive shell is now zsh"
+export BASH_SILENCE_DEPRECATION_WARNING=1
+
 shopt -s histappend
 shopt -s cmdhist
 shopt -s checkwinsize


### PR DESCRIPTION
Hide "default interactive shell is now zsh" with `BASH_SILENCE_DEPRECATION_WARNING` env variable.

