### PR TITLE
Add Bash completion for Github Cli

### DIFF
--- a/bash/github.bash
+++ b/bash/github.bash
@@ -1,0 +1,1 @@
+eval "$(gh completion -s bash)"

--- a/bash/github.bash
+++ b/bash/github.bash
@@ -1,1 +1,0 @@
-eval "$(gh completion -s bash)"

--- a/github/completion.bash
+++ b/github/completion.bash
@@ -1,0 +1,3 @@
+if brew ls --versions gh > /dev/null; then
+  eval "$(gh completion -s bash)"
+fi


### PR DESCRIPTION
Add Bash completion for [Github Cli ](https://cli.github.com/)
Should be installed with `brew install github/gh/gh`